### PR TITLE
fix: handle single `a` token

### DIFF
--- a/src/v2/convertTokens/index.ts
+++ b/src/v2/convertTokens/index.ts
@@ -25,7 +25,7 @@ const tokensMap: TokensMap = {
   ddd: 'iii',
   dddd: 'iiii',
   A: 'a',
-  a: 'a',
+  a: 'aaaaa\'m\'',
   aa: 'aaaa',
   E: 'i',
   W: 'I',

--- a/src/v2/convertTokens/test.ts
+++ b/src/v2/convertTokens/test.ts
@@ -266,6 +266,11 @@ describe('format', () => {
     })
 
     describe('hours and am/pm', () => {
+      it('12 am', () => {
+        const date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
+        assert(format(date, convertTokens('h:mm a')) === '12:00 am')
+      })
+
       it('12 a.m.', () => {
         const date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
         assert(format(date, convertTokens('h:mm aa')) === '12:00 a.m.')


### PR DESCRIPTION
Discovered a bug while running migration verification tests from v1 to v2 with our codebase. `convertTokens` is not handling the `a` token correctly. In v1, `a => am` but in v2 `a => AM` and this needs to be handled.

Related https://github.com/date-fns/date-fns/issues/946

## Changes

- Add test case for converting `a` token