### PR TITLE
chore(package): use wildcard version for 1.x/2.x isDate, typings, build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.3",
   "description": "A tool for upgrading date-fns versions",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": "https://github.com/date-fns/date-fns-upgrade",
   "author": "Sasha Koss <koss@nocorp.me>",
   "license": "MIT",
@@ -19,9 +20,10 @@
     "typescript": "^3.5.2"
   },
   "dependencies": {
-    "date-fns": "^2.1"
+    "date-fns": "*"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "build": "tsc -p ."
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,10 +1421,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^2.1:
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.11.1.tgz#197b8be1bbf5c5e6fe8bea817f0fe111820e7a12"
-  integrity sha512-3RdUoinZ43URd2MJcquzBbDQo+J87cSzB8NkXdZiN5ia1UNyep0oCyitfiL88+R7clGTeq/RniXAc16gWyAu1w==
+date-fns@*:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"


### PR DESCRIPTION
I'm using this package to help do a very large migration and I noticed that the _only_ function being used is `isDate` from `date-fns`. However, we are actually looking at using date-fns 1.x and 2.x side-by-side using package aliasing to help do a granular migration but the problem is that this package will bring in date-fns 2.x even though there's no difference between behavior for `isDate` from v1 / v2, and there's an extra `date-fns` brought into the node_modules tree.

I'd have to dig into whether this impacts bundle size inadvertently but I don't see too much of an issue using a wildcard version if only depending on `isDate`.

## Changes

- Use `*` dependency versioning to support `date-fns` 1.x and 2.x during a migration scenario
- Add `types` for good measure
- Add a build script for contributors